### PR TITLE
feat: Accept raw service account JSON instead of base64

### DIFF
--- a/lib/app_check/app_check_config.dart
+++ b/lib/app_check/app_check_config.dart
@@ -13,7 +13,7 @@ class AppCheckConfig {
   /// Firebase project ID
   final String firebaseProjectId;
 
-  /// Base64 encoded Firebase service account JSON
+  /// Firebase service account JSON as a string
   final String serviceAccountJson;
 
   /// Whether to bypass App Check in development mode

--- a/lib/app_check/firebase_app_check_service.dart
+++ b/lib/app_check/firebase_app_check_service.dart
@@ -23,9 +23,8 @@ class FirebaseAppCheckService {
     if (_appCheck != null) return _appCheck!;
 
     try {
-      // Decode the base64 service account JSON
-      final serviceAccount = base64.decode(_config.serviceAccountJson);
-      final serviceAccountJson = utf8.decode(serviceAccount);
+      // Use the service account JSON directly (no base64 decoding needed)
+      final serviceAccountJson = _config.serviceAccountJson;
 
       // Create a temporary file for the service account
       final tempFile = File.fromUri(

--- a/test/app_check/app_check_config_test.dart
+++ b/test/app_check/app_check_config_test.dart
@@ -4,10 +4,10 @@ import 'package:test/test.dart';
 void main() {
   group('AppCheckConfig', () {
     test('should create config with required parameters', () {
-      const config = AppCheckConfig(firebaseProjectId: 'test-project', serviceAccountJson: 'base64-encoded-json');
+      const config = AppCheckConfig(firebaseProjectId: 'test-project', serviceAccountJson: '{"type": "service_account"}');
 
       expect(config.firebaseProjectId, equals('test-project'));
-      expect(config.serviceAccountJson, equals('base64-encoded-json'));
+      expect(config.serviceAccountJson, equals('{"type": "service_account"}'));
       expect(config.enableDevMode, isFalse);
       expect(config.exemptPaths, isEmpty);
       expect(config.cacheMaxSize, equals(1000));
@@ -17,7 +17,7 @@ void main() {
     test('should create config with all parameters', () {
       const config = AppCheckConfig(
         firebaseProjectId: 'test-project',
-        serviceAccountJson: 'base64-encoded-json',
+        serviceAccountJson: '{"type": "service_account"}',
         enableDevMode: true,
         exemptPaths: ['/ping', '/health'],
         cacheMaxSize: 500,
@@ -25,7 +25,7 @@ void main() {
       );
 
       expect(config.firebaseProjectId, equals('test-project'));
-      expect(config.serviceAccountJson, equals('base64-encoded-json'));
+      expect(config.serviceAccountJson, equals('{"type": "service_account"}'));
       expect(config.enableDevMode, isTrue);
       expect(config.exemptPaths, equals(['/ping', '/health']));
       expect(config.cacheMaxSize, equals(500));

--- a/test/app_check/app_check_middleware_test.dart
+++ b/test/app_check/app_check_middleware_test.dart
@@ -31,7 +31,7 @@ void main() {
     test('should bypass App Check in dev mode', () async {
       const config = AppCheckConfig(
         firebaseProjectId: 'test-project',
-        serviceAccountJson: 'base64-json',
+        serviceAccountJson: '{"type": "service_account"}',
         enableDevMode: true,
       );
 
@@ -46,7 +46,7 @@ void main() {
     test('should bypass App Check for exempt paths', () async {
       const config = AppCheckConfig(
         firebaseProjectId: 'test-project',
-        serviceAccountJson: 'base64-json',
+        serviceAccountJson: '{"type": "service_account"}',
         exemptPaths: ['/ping'],
       );
 
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('should return 401 for missing App Check header', () async {
-      const config = AppCheckConfig(firebaseProjectId: 'test-project', serviceAccountJson: 'base64-json');
+      const config = AppCheckConfig(firebaseProjectId: 'test-project', serviceAccountJson: '{"type": "service_account"}');
 
       final middleware = appCheckMiddleware(config: config);
       final middlewareHandler = middleware(handler);
@@ -72,7 +72,7 @@ void main() {
     });
 
     test('should return 401 for empty App Check header', () async {
-      const config = AppCheckConfig(firebaseProjectId: 'test-project', serviceAccountJson: 'base64-json');
+      const config = AppCheckConfig(firebaseProjectId: 'test-project', serviceAccountJson: '{"type": "service_account"}');
 
       when(() => request.headers).thenReturn({'X-Firebase-AppCheck': ''});
 


### PR DESCRIPTION
## Summary
- Updated `AppCheckConfig` to accept raw service account JSON string instead of base64 encoded string
- Removed base64 decoding logic from `FirebaseAppCheckService` 
- Updated all tests to use raw JSON examples instead of base64 placeholders
- Updated documentation comments to reflect the API change

## Changes Made
- **lib/app_check/app_check_config.dart**: Updated documentation comment from "Base64 encoded Firebase service account JSON" to "Firebase service account JSON as a string"
- **lib/app_check/firebase_app_check_service.dart**: Removed `base64.decode()` and `utf8.decode()` calls, now uses `_config.serviceAccountJson` directly
- **test/app_check/app_check_config_test.dart**: Updated test values from `'base64-encoded-json'` to `'{"type": "service_account"}'`
- **test/app_check/app_check_middleware_test.dart**: Updated test values from `'base64-json'` to `'{"type": "service_account"}'`

## Rationale
This change simplifies the API by removing the need for clients to base64 encode their service account JSON before passing it to the library. The raw JSON string is more intuitive and aligns with standard Firebase SDK patterns.

## Test Plan
- [x] All existing tests pass
- [x] Updated test values to use realistic JSON structure
- [x] Verified that the service still creates temporary files correctly
- [x] Confirmed that Firebase Admin SDK initialization works with raw JSON

🤖 Generated with [Claude Code](https://claude.ai/code)